### PR TITLE
Add a first-pass of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ pip install -e .[dev]
 ```
 Please use `pip install -e '.[dev]'` if you are a `zsh` user.
 
+#### Building documentation locally
+
+Set yourself up to use the `[dev]` dependencies. Then, from the command line run:
+```bash
+mkdocs build
+```
+
 ---
 
 ## Motivation

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,0 +1,32 @@
+"""Generate the code reference pages."""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+for path in sorted(Path("qtcodes").rglob("*.py")):
+    module_path = path.relative_to(".").with_suffix("")
+    doc_path = path.relative_to(".").with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
+
+    parts = list(module_path.parts)
+
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1] == "__main__":
+        continue
+
+    nav[parts] = str(doc_path)
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        identifier = ".".join(parts)
+        print("::: " + identifier, file=fd)
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+
+with mkdocs_gen_files.open("reference/summary.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+Quantum computation is an inherently noisy process. Scalable quantum computers will require fault-tolerance to implement useful computation. There are many proposed approaches to this, but one promising candidate is the family of *topological quantum error correcting codes*.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: qtcodes
+
+theme:
+  name: "material"
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+      - docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: summary.md
+  - section-index
+  - mkdocstrings:
+      watch:
+      - docs
+      - qtcodes
+
+nav:
+  - About: index.md
+  - Setup: setup.md
+  - Code Reference: reference/

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,18 @@ REQUIREMENTS = [
 ]
 
 EXTRA_REQUIREMENTS = {
-    "dev": ["jupyterlab>=3.1.0", "mypy", "pylint", "black"],
+    "dev": [
+        "jupyterlab>=3.1.0",
+        "mypy",
+        "pylint",
+        "black",
+        "mkdocs",
+        "mkdocs-material",
+        "mkdocs-gen-files",
+        "mkdocs-literate-nav",
+        "mkdocs-section-index",
+        "mkdocstrings",
+    ],
 }
 
 # Read long description from README.


### PR DESCRIPTION
Resolves #30

The goal of #30 was to get some initial documentation added to the package. My main focus in this task was to make it as automated as possible to generate documentation. In the event that we want to include this as a CI job in the future, having a good auto-generation pipeline is key.

So, I started by looking at the built-in pydoc support, but hey this is 2022! My eyes bleed when I see something like this:
![image](https://user-images.githubusercontent.com/904110/160016124-a1cb4e20-5a28-4e46-b560-8839d31da010.png)

Next, I looked at what others were using for hosted documentation on sites like [readthedocs](https://readthedocs.org/). One toolkit that seems to be popular for generating readthedocs-compatible documentation is [sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html). Sphinx has [auto-generation](https://www.sphinx-doc.org/en/master/man/sphinx-autogen.html), but I've anecdotally heard of [issues](https://github.com/unitaryfund/mitiq/issues?q=is%3Aissue+readthedocs+or+RTD) with readthedocs from the Mitiq team.

I wanted something Markdown friendly instead of reStructuredText, which is what sphinx uses, so I landed on [MkDocs](https://www.mkdocs.org/getting-started/). MkDocs has beautiful templates, a plugin architecture, and an [docs auto-generating plugin](https://oprypin.github.io/mkdocs-gen-files/#usage). After following a [recipe](https://mkdocstrings.github.io/recipes/) on the main MkDocs website, I was able to get a site up-and-running.

I tried pushing pages directly to the wiki github repo, which is a subrepo of this repo, but when you link to an html page from a wiki markdown page it ends up loading the html in "raw" mode. There are restrictions as to what html tags are supported, too. So, there was no way to simply embed an iframe on the main wiki page and have the generated documentation come through. There may still be a possibility to get this to work, but I landed on another solution below that seemed to have less friction.

MkDocs has support to deploy to `gh-pages` via the command line, which will build the site, create an orphaned branch called `gh-pages` and push that branch up to the server. It's as simple as running:
```bash
mkdocs gh-deploy
```

For hosting, we enabled GitHub pages in the settings:
![image](https://user-images.githubusercontent.com/904110/160017072-ace27b79-bc05-4ffa-a252-2b7e3de990ec.png)

Once that was enabled, within a few minutes we had a [beautiful documentation site up](https://yaleqc.com/qtcodes)! 

_NOTE: For anyone else who may come across this -- if you are worried that you might clobber your main GitHub pages site by deploying from a branch from another repository, then the good news is that it won't! Your repository gh-pages site will live under a subdirectory, matching the name of the repository, under the domain._